### PR TITLE
Some fixes to for better Metropolia thesis guideline support.

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -49,7 +49,7 @@ Etunimi Sukunimi, Titteli\newline
 Etunimi Sukunimi, Titteli
 }
 \def\avainsanat{avainsanat}
-\def\pvm{\ddmmyyyydate\today}
+\def\pvm{\specialdate\today}
 
 %English section, for abstract
 \title{Your title here}
@@ -119,6 +119,26 @@ First name Last name, Title (for example: Principal Lecturer)
 \usepackage{tabularx}
 \usepackage{booktabs} %why not booktabs? :3
 
+\usepackage{float} % For forced figure location with modifier H (\begin{figure}[H])
+\usepackage{cite} % Make citations to match Metropolia thesis guide
+
+% change font of links in bibliography to same as other text
+\usepackage{url}
+\urlstyle{same}
+
+% change punctuation of multiple cites to semicolon instead of comma: [1; 2; 3]
+\renewcommand\citepunct{; }
+
+% citep-macro for reference with period inside square brackets [1.]
+\newcommand{\citep}[1]{
+ \renewcommand\citeright{.]}
+ \cite{#1}
+ \renewcommand\citeright{]}
+}
+
+%set date format to MM.YYYY
+\newdateformat{specialdate}{\twodigit{\THEMONTH}.\THEYEAR}
+
 \newcommand\tn[1]{\textnormal{#1}} %use \tn instead of \textnormal
 \newcommand\reaction[1]{\begin{equation}\ce{#1}\end{equation}} %\reaction{} for chemical reactions
 
@@ -183,6 +203,10 @@ xleftmargin=1cm
 \IfLanguageName {finnish} {\renewcommand{\lstlistingname}{Listaus}} {} % what is a good translation for this?
 %\counterwithout{lstlisting}{chapter}
 %moved after begin document, otherwise does not compile
+
+%% set this format as the default for lstlisting
+\DeclareCaptionFormat{empty}{}
+\captionsetup[lstlisting]{format=empty}
 
 %TOC
 %change toc title
@@ -270,7 +294,7 @@ xleftmargin=1cm
   \metropoliadegree \\
   \metropoliadegreeprogramme \\
   \thesis\\
-  \ddmmyyyydate\today %to be checked date format? 
+  \specialdate\today % MM.YYYY date format
 }
 }
 \ThisLRCornerWallPaper{1}{metropolia}
@@ -434,6 +458,8 @@ TL;DR & Too long, didn't read\\
 %----------------------------------------------------------------------------------------
 %	CONTENT
 %----------------------------------------------------------------------------------------
+
+\sloppy % enforce alignment to fully justified
 
 \chapter{Content}
 This should be \textbf{bold} and this \textit{italic} and finally \textbf{\textit{bolditalic}}. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam aliquam aliquam purus, in ornare nulla imperdiet molestie. Nam tempus erat eu dui rhoncus et vestibulum mi elementum. Ut porttitor elit sit amet justo dignissim sit amet sagittis massa egestas. Mauris sed dolor eget dui fermentum sodales ut eu nibh. 

--- a/vancouver_fi.bst
+++ b/vancouver_fi.bst
@@ -53,7 +53,8 @@
 
 %% List of all possible fields
 ENTRY
-  { address
+  { title
+    address
     assignee     % for patents
     author
     booktitle    % for articles in books
@@ -76,7 +77,6 @@ ENTRY
     publisher
     school
     series
-    title
     type
     volume
     word
@@ -96,7 +96,8 @@ INTEGERS { hrefform addeprints adddoiresolver }
 % Following constants may be adjusted by hand, if desired
 FUNCTION {init.config.constants}
 {
-  "Saatavilla: " 'urlintro := % prefix before URL
+  %"Saatavilla: " 'urlintro := % prefix before URL
+  "" 'urlintro := % prefix before URL
   "http://arxiv.org/abs/" 'eprinturl := % prefix to make URL from eprint ref
   "arXiv:" 'eprintprefix := % text prefix printed before eprint ref
   "http://dx.doi.org/" 'doiurl := % prefix to make URL from DOI
@@ -196,8 +197,8 @@ FUNCTION {format.lastchecked}
 { lastchecked empty$
     { "" }
     { updated empty$
-      { inbrackets "viitattu " lastchecked * }
-      { inbrackets "päivitetty " updated * "; viitattu " * lastchecked * }
+      { "Luettu " lastchecked * }
+      { "Päivitetty " updated * "; Luettu " * lastchecked * }
     if$
     }
   if$
@@ -818,7 +819,14 @@ FUNCTION {format.names.ed}
 
 FUNCTION {format.authors}
 { 
-  author "author" format.names
+  %%author "author" format.names
+  author "author" bibinfo.check
+  %%"." " " "author" find.replace format.names
+}
+
+FUNCTION {format.publishers}
+{ 
+  publisher "publisher" bibinfo.check
   %%"." " " "author" find.replace format.names
 }
 
@@ -903,16 +911,13 @@ FUNCTION {format.note}
 
 FUNCTION {format.title}
 { title
-%%duplicate$ empty$ 'skip$
-%%  { "t" change.case$ }
-%%if$
   "title" bibinfo.check
 }
 
 FUNCTION {format.type}
 { type empty$
     'skip$
-    { inbrackets type }
+    { type }
     %%{ add.blank "[" type * "]" * }
   if$
 }
@@ -991,7 +996,7 @@ FUNCTION {format.journal.date}
 FUNCTION {format.date}
 {
   no.blank.or.punct
-  ";" 
+  "." 
   duplicate$ empty$
   year  "year"  bibinfo.check duplicate$ empty$
     { swap$ 'skip$
@@ -1381,8 +1386,8 @@ FUNCTION {format.url}
     { "" }
       { hrefform #1 =
           { % special case -- add HyperTeX specials
-            urlintro "\url{" url * "}" * url make.href.hypertex * }
-          { urlintro "\url{" * url * "}" * }
+            urlintro "<\url{" url * "}>" * url make.href.hypertex * }
+          { urlintro "<\url{" * url * "}>" * }
        if$
      }
   if$
@@ -1520,9 +1525,10 @@ FUNCTION {webpage}
 
 FUNCTION {misc}
 { output.bibitem
+  format.title "title" output.check
+  format.date "year" output.check
   format.authors "author" output.check
   format.editors "author and editor" output.check
-  format.title "title" output.check
   type missing$
     { skip$ }
     { format.type "type" output.check }
@@ -1530,7 +1536,23 @@ FUNCTION {misc}
   if$
   new.block
   format.publisher.address output
+  new.block
+  format.note output
+  new.block
+  howpublished new.block.checka
+  howpublished "howpublished" bibinfo.check output
+  output.web.refs  % urlbst
+  fin.entry
+  empty.misc.check
+}
+
+FUNCTION {online}
+{ output.bibitem
+  format.authors "author" output.check
+  format.title "title" output.check
   format.date "year" output.check
+  format.type "Verkkodokumentti" output
+  format.publishers "publisher" output.check
   new.block
   format.note output
   new.block


### PR DESCRIPTION
These modifications are mosty result of feedback and required changes from text control step of my thesis (Metropolia Leppävaara, Tietotekniikka). 

* Date changed to only MM/YYYY
* Force fully justified alignment of document
* Added citep-macro for getting citations with period inside brackets
* Multiple changes to bibliography (updated some texts, added special handling for online-type, changed order of fields, urls inside <>, changed font of urls to match rest of document, etc...)

Known bugs/limitations:
* Authors in bibliography are deployed as written so names must be already in correct format in bib-file.
* For bibliography online-type, word "Verkkodokumentti" is added regardless of used language.