### PR TITLE
fix citation field order

### DIFF
--- a/vancouver_fi.bst
+++ b/vancouver_fi.bst
@@ -1548,9 +1548,18 @@ FUNCTION {misc}
 
 FUNCTION {online}
 { output.bibitem
-  format.authors "author" output.check
-  format.title "title" output.check
-  format.date "year" output.check
+
+  author empty$
+    { format.title "title" output.check output
+      format.date "year" output.check output
+    }
+    { format.authors "author" output.check output
+      format.date "year" output.check output
+      format.title "title" output.check output
+    }
+  if$
+  
+
   format.type "Verkkodokumentti" output
   format.publishers "publisher" output.check
   new.block


### PR DESCRIPTION
Change citation field order so that date (year) is always second field. This was required by reviser and it corresponds with thesis guide.